### PR TITLE
fix #3: make the default constructor find its own default directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,8 @@ import (
 )
 
 func main() {
-	dir, err := os.UserConfigDir()
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(dir)
-
 	// the standard location is config-dir/envy
-
-	e, err := envy.New(path.Join(dir, "envy"))
+	e, err := envy.New()
 
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/matt4biz/envy"
@@ -137,15 +135,7 @@ func runApp(args []string, version string, stdin io.Reader, stdout, stderr io.Wr
 	}
 
 	if cmd.NeedsDB() {
-		p, err := os.UserConfigDir()
-
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return -1
-		}
-
-		a.path = path.Join(p, "envy")
-		a.Envy, err = envy.New(a.path)
+		a.Envy, err = envy.New()
 
 		if err != nil {
 			fmt.Fprintln(stderr, err)

--- a/envy_test.go
+++ b/envy_test.go
@@ -28,7 +28,7 @@ func TestEnvy(t *testing.T) { //nolint:gocyclo
 
 	defer os.RemoveAll(dname)
 
-	e, err := New(dname)
+	e, err := NewWithDirectory(dname)
 
 	if err != nil {
 		t.Fatal("new", err)
@@ -115,4 +115,14 @@ func TestEnvy(t *testing.T) { //nolint:gocyclo
 	} else if string(j) != jorig {
 		t.Errorf("invalid json: %s (should be %s)", string(j), jorig)
 	}
+}
+
+func TestDefaultDirectory(t *testing.T) {
+	d, err := defaultDirectory()
+
+	if err != nil || d == "" {
+		t.Fatalf("invalid default: [%s]: %s", d, err)
+	}
+
+	t.Log(d)
 }


### PR DESCRIPTION
This is a breaking change; no parameters for envy.New