### PR TITLE
Add an option to unquote embedded JSON

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -104,8 +104,9 @@ Usage:
   list [opts] realm[/key]
     -d  show decrypted secrets also
   read        realm       file
+    -q  unquote embedded JSON in values
+  write       realm       file
     -clear  overwrite contents
-  dump        realm       file
   version
 
 Listing a realm displays a timestamp, size, and hash for each key-value pair.

--- a/cmd/write_test.go
+++ b/cmd/write_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestRead(t *testing.T) {
+func TestWrite(t *testing.T) {
 	dname, err := ioutil.TempDir("", "scratch")
 
 	if err != nil {
@@ -56,7 +56,7 @@ func TestRead(t *testing.T) {
 	}
 }
 
-func TestReadOverwrite(t *testing.T) {
+func TestOverwrite(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	app := NewTestApp(t, stdout, stderr)


### PR DESCRIPTION
Remove extra quotes around {} and un-escaping quotes on strings

```
$ envy add test a='{"one":{"a":"1","b":"2"},\n "two":{"a":"5","b":"6"}}'
```

which would normally be output as

```
{"a": "{\"one\":{\"a\":\"1\",\"b\":\"2\"},\\n \"two\":{\"a\":\"5\",\"b\":\"6\"}}"}
```

now becomes 

```
{"a":{"one":{"a":"1","b":"2"}, "two":{"a":"5","b":"6"}}}
```
